### PR TITLE
Fix for crash when (accidentally) loaded on server

### DIFF
--- a/src/main/java/com/minenash/rebind_all_the_keys/RebindAllTheKeys.java
+++ b/src/main/java/com/minenash/rebind_all_the_keys/RebindAllTheKeys.java
@@ -1,8 +1,8 @@
 package com.minenash.rebind_all_the_keys;
 
+import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.options.KeyBinding;
@@ -17,7 +17,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Environment(EnvType.CLIENT)
-public class RebindAllTheKeys implements ModInitializer {
+public class RebindAllTheKeys implements ClientModInitializer {
 
 	public static boolean isAmecsInstalled = false;
 
@@ -57,7 +57,7 @@ public class RebindAllTheKeys implements ModInitializer {
 
 
 	@Override
-	public void onInitialize() {
+	public void onInitializeClient() {
 		KeyBindingHelper.registerKeyBinding(DEBUG_KEY);
 		KeyBindingHelper.registerKeyBinding(RELOAD_CHUNKS);
 		KeyBindingHelper.registerKeyBinding(SHOW_HITBOXES);

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -17,7 +17,7 @@
 
   "environment": "*",
   "entrypoints": {
-    "main": [
+    "client": [
       "com.minenash.rebind_all_the_keys.RebindAllTheKeys"
     ]
   },
@@ -29,5 +29,9 @@
     "fabricloader": ">=0.7.4",
     "fabric": "*",
     "minecraft": ">=1.16.2"
+  },
+
+  "custom": {
+    "modmenu:clientsideOnly": true
   }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "icon": "assets/modid/icon.png",
 
-  "environment": "*",
+  "environment": "client",
   "entrypoints": {
     "client": [
       "com.minenash.rebind_all_the_keys.RebindAllTheKeys"
@@ -29,9 +29,5 @@
     "fabricloader": ">=0.7.4",
     "fabric": "*",
     "minecraft": ">=1.16.2"
-  },
-
-  "custom": {
-    "modmenu:clientsideOnly": true
   }
 }

--- a/src/main/resources/rebind_all_the_keys.mixins.json
+++ b/src/main/resources/rebind_all_the_keys.mixins.json
@@ -3,14 +3,12 @@
   "minVersion": "0.8",
   "package": "com.minenash.rebind_all_the_keys.mixin",
   "compatibilityLevel": "JAVA_8",
-  "mixins": [
-    "GameOptionsMixin"
-  ],
   "client": [
     "ControlsListWidgetKeyBindingEntryMixin",
     "ControlsOptionsScreenMixin",
     "DebugHudMixin",
     "GameModeSelectionScreenMixin",
+    "GameOptionsMixin",
     "InputKeyMixin",
     "InputUtilKeyMixin",
     "InputUtilTypeAccessor",


### PR DESCRIPTION
`GameOptions` does not exist on the server, so the mixin should be client-side only.
Also use `ClientModInitializer` and add the client label for mod menu.